### PR TITLE
Verson 7

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -41,6 +41,7 @@ class Extension {
 			this.move_panel(monitor);
 			this.move_hotcorners(monitor);
 			this.move_notifications(monitor);
+			this.fix_trayIconsReloaded();
 		}
 	}
 	
@@ -108,6 +109,23 @@ class Extension {
 		func = func.replace('_getDraggableWindowForPosition(', 'function(');
 		eval(`Main.panel._getDraggableWindowForPosition = ${func}`);
 	}
+
+	fix_trayIconsReloaded() {
+		const extension = Main.extensionManager.lookup('trayIconsReloaded@selfmade.pl');
+		if (extension && extension.state === ExtensionUtils.ExtensionState.ENABLED) {
+			if (!extension.stateObj._rebuild) {
+				extension.stateObj._rebuild = function() {
+					this.TrayIcons._destroy();
+					this.TrayIcons = new extension.imports.extension.TrayIconsClass(this._settings);
+					this._setTrayMargin();
+					this._setIconSize();
+					this._setTrayArea();
+				};
+			}
+	
+			extension.stateObj._rebuild();
+		}
+	}
 	
 	enable() {
 		this._original_updateState = MT._updateState;
@@ -131,5 +149,5 @@ class Extension {
 
 function init() {
 	ExtensionUtils.initTranslations();
-    return new Extension();
+	return new Extension();
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -78,38 +78,42 @@ class Extension {
 		}
 	}
 
+	// To show notification on the second screen after moving the panel
 	patch_updateState() {
 		const patches = [
 			{ from: 'Main.layoutManager.primaryMonitor.', to: 'Main.layoutManager.monitors[this._constraint.index].' },
+			{ from: 'Main.', to: 'imports.ui.main.' },
+			{ from: 'State.', to: 'imports.ui.messageTray.State.' },
+			{ from: 'Urgency.', to: 'imports.ui.messageTray.Urgency.' },
 		];
-
-		const { State, Urgency } = imports.ui.messageTray; // used in _updateState(), do not remove
-
-		let func = this._original_updateState.toString();
-		for (const { from, to } of patches) {
-			func = func.replaceAll(from, to);
-		}
 	
-		func = func.replace('_updateState(', 'function(');
-		eval(`MT._updateState = ${func}`);
+		const func = this._original_updateState.toString();
+		MT._updateState = this.patch_function(func, patches);
 	}
-
+	
+	// To grab a window from the second screen after moving the panel (fixes #5)
 	patch_getDraggableWindowForPosition() {
 		const patches = [
 			{ from: 'metaWindow.is_on_primary_monitor()', to: 'true' },
+			{ from: 'Main.', to: 'imports.ui.main.' },
+			{ from: 'Meta.', to: 'imports.gi.Meta.' },
 		];
-
-		const { Meta } = imports.gi; // used in _getDraggableWindowForPosition(), do not remove
-
-		let func = this._original_getDraggableWindowForPosition.toString();
+	
+		const func = this._original_getDraggableWindowForPosition.toString();
+		Main.panel._getDraggableWindowForPosition = this.patch_function(func, patches);
+	}
+	
+	patch_function(func, patches) {
+		let args = func.substring(func.indexOf('(') + 1, func.indexOf(')')).split(', ');
+		let body = func.substring(func.indexOf('{') + 1, func.lastIndexOf('}'));
 		for (const { from, to } of patches) {
-			func = func.replaceAll(from, to);
+			body = body.replaceAll(from, to);
 		}
 	
-		func = func.replace('_getDraggableWindowForPosition(', 'function(');
-		eval(`Main.panel._getDraggableWindowForPosition = ${func}`);
+		return new Function(args, body);
 	}
 
+	// Rebuild tray icons to fix the problem with a icon placement when the top panel has been moved
 	fix_trayIconsReloaded() {
 		const extension = Main.extensionManager.lookup('trayIconsReloaded@selfmade.pl');
 		if (extension && extension.state === ExtensionUtils.ExtensionState.ENABLED) {

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,5 +7,5 @@
 	"description": "Moves the top panel to the secondary monitor if the primary is in fullscreen", 
 	"url": "https://github.com/Noobsai/fullscreen-avoider", 
 	"version": 6,
-	"shell-version": ["40", "41"]
+	"shell-version": ["40", "41", "42"]
 }

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -6,6 +6,6 @@
 	"settings-schema": "org.gnome.shell.extensions.fullscreen-avoider",
 	"description": "Moves the top panel to the secondary monitor if the primary is in fullscreen", 
 	"url": "https://github.com/Noobsai/fullscreen-avoider", 
-	"version": 6,
+	"version": 7,
 	"shell-version": ["40", "41", "42"]
 }


### PR DESCRIPTION
[Added fix for trayIconsReloaded](https://github.com/Noobsai/fullscreen-avoider/commit/060ae2625d7b7dbe480470d2c73631256c776e5f)
[Added gnome-shell 42 support](https://github.com/Noobsai/fullscreen-avoider/commit/298cbe1586338886d7cf770a985acd0f500a855f)
[Removed eval(). Using 'new Function()' constructor](https://github.com/Noobsai/fullscreen-avoider/commit/3753abe025c21b1785ddb77286ec64fb549f8ea7)