### PR TITLE
Added shell version 43 to metadata.json

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,5 +7,5 @@
 	"description": "Moves the top panel to the secondary monitor if the primary is in fullscreen", 
 	"url": "https://github.com/Noobsai/fullscreen-avoider", 
 	"version": 7,
-	"shell-version": ["40", "41", "42"]
+	"shell-version": ["40", "41", "42", "43"]
 }


### PR DESCRIPTION
As the commit says, only changed the metadata. Haven't noticed any issues yet after using it for a few days on Gnome 43, Fedora Workstation 37 Beta.