### PR TITLE
Add Gnome 44 support

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,5 +7,5 @@
 	"description": "Moves the top panel to the secondary monitor if the primary is in fullscreen", 
 	"url": "https://github.com/Noobsai/fullscreen-avoider", 
 	"version": 8,
-	"shell-version": ["40", "41", "42", "43"]
+	"shell-version": ["40", "41", "42", "43", "44"]
 }


### PR DESCRIPTION
Since Gnome requires the version to be explicitly mentioned in the metadata, here's a pull request to add version 44 to the list of supported versions. I have tried the patch locally, and it works without problems, so I assume there are no breaking changes from gnome's side.