### PR TITLE
Option to permanently move topbar to second monitor.

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -8,8 +8,6 @@ const MT = Main.messageTray;
 const Display = global.display;
 const ExtensionUtils = imports.misc.extensionUtils;
 
-imports.ui.main.layoutManager.monitors
-
 class Extension {
 	get_unfullscreen_monitor() {
 		for (const monitor of LM.monitors) {
@@ -32,7 +30,8 @@ class Extension {
 	
 		if (primary_monitor.inFullscreen) {
 			this.move_all(unfullscreen_monitor);
-		} else {
+		} 
+		else {
 			this.move_all(primary_monitor);
 		}
 	}

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -26,6 +26,7 @@ function buildPrefsWidget() {
 
 	box.append(buildSwitcher(settings, 'move-hot-corners', _('Move Hot Corners:')));
 	box.append(buildSwitcher(settings, 'move-notifications', _('Move Notifications:')));
+	box.append(buildSwitcher(settings, 'permanent-move', _('Permanently Move Topbar:')));
 
 	return box;
 }

--- a/src/schemas/org.gnome.shell.extensions.fullscreen-avoider.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.fullscreen-avoider.gschema.xml
@@ -10,5 +10,10 @@
       <summary>Move Notifications</summary>
       <description>Move Notifications</description>
     </key>
+        <key name="permanent-move" type="b">
+      <default>false</default>
+      <summary>Permanently Move Topbar</summary>
+      <description>Permanently Move Topbar</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
An option I added because I like games and other programs to default to opening on my primary monitor, but I prefer the top bar, notifications and hot corners to be on my secondary.